### PR TITLE
Update SQLClient.m

### DIFF
--- a/SQLClient/SQLClient/SQLClient/SQLClient.m
+++ b/SQLClient/SQLClient/SQLClient/SQLClient.m
@@ -74,7 +74,7 @@ struct COL
 
 #pragma mark - Public
 
-+ (id)sharedInstance
++ (instancetype)sharedInstance
 {
     static SQLClient* sharedInstance = nil;
     static dispatch_once_t onceToken;


### PR DESCRIPTION
Using instancetype as the sharedInstance return type prevents having to cast this return for direct use of the properties and methods.  For example, with this change, the following is possible: [SQLClient sharedInstance].timeout = 3;  Without the change, you'd have to first save it to a variable or do the following ((SQLClient*)[SQLClient sharedInstance]).timeout = 3;
