### PR TITLE
Update SQLClient.h

### DIFF
--- a/SQLClient/SQLClient/SQLClient/SQLClient.h
+++ b/SQLClient/SQLClient/SQLClient/SQLClient.h
@@ -83,7 +83,7 @@
  *
  *  @return Shared SQLClient object
  */
-+ (id)sharedInstance;
++ (instancetype)sharedInstance;
 
 /**
  *  Connects to a SQL database server


### PR DESCRIPTION
Using instancetype as the sharedInstance return type prevents having to cast this return for direct use of the properties and methods.  For example, with this change, the following is possible: [SQLClient sharedInstance].timeout = 3;  Without the change, you'd have to first save it to a variable or do the following ((SQLClient*)[SQLClient sharedInstance]).timeout = 3;
