### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Open the Xcode project inside the **SQLClient** folder.
 <a href="http://cocoapods.org/?q=sqlclient">CocoaPods</a> is the preferred way to install this library.
 
 1. Open a Terminal window. Update RubyGems by entering: `sudo gem update --system`. Enter your password when prompted.
-2. Install Cocoapods by entering `sudo gem install cocoapods`.
+2. Install CocoaPods by entering `sudo gem install cocoapods`.
 3. Create a file at the root of your Xcode project folder called **Podfile**.
 4. Enter the following text: `pod 'SQLClient', '~> 0.1.3'`
 4. In Terminal navigate to this folder and enter `pod install`.


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
