### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Open the Xcode project inside the **SQLClient** folder.
 3. Create a file at the root of your Xcode project folder called **Podfile**.
 4. Enter the following text: `pod 'SQLClient', '~> 0.1.3'`
 4. In Terminal navigate to this folder and enter `pod install`.
-5. You will see a new **SQLClient.xcworkspace** file. Open this file in XCode to work with this project from now on.
+5. You will see a new **SQLClient.xcworkspace** file. Open this file in Xcode to work with this project from now on.
 
 ###Manual
 


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
